### PR TITLE
Small grammatical changes and fixed typos in docs

### DIFF
--- a/src/content/docs/en/concepts/async-await.mdx
+++ b/src/content/docs/en/concepts/async-await.mdx
@@ -10,7 +10,7 @@ import { PokemonProfile } from  "~/xania/PokemonProfile";
 import { PokemonApp } from "~/xania/PokemonApp";
 
 In **Xania**, using async / await is not limited to only *server components*. 
-In the following example we call `fetchPokemon` from inside our Component. We can do this because a *Function Component* is just a regular function that happens to returns a view. In fact, calling `Pokemon({ id : 1})` is equivalent to `<Pokemon id={1}>`
+In the following example we call `fetchPokemon` from inside our Component. We can do this because a *Function Component* is just a regular function that happens to return a view. In fact, calling `Pokemon({ id : 1})` is equivalent to `<Pokemon id={1}>`
 
 
 ```jsx { 2 }
@@ -33,7 +33,7 @@ async function Pokemon(props: { id }) {
 ```
 <PokemonProfile id="ditto" client:only="xania"  />
 
-And for completeness here is the implementation of fetchPokemon we used above
+And for completeness, here is the implementation of fetchPokemon we used above:
 
 ```typescript
 type Pokemon = { name: string }

--- a/src/content/docs/en/concepts/derived-state.mdx
+++ b/src/content/docs/en/concepts/derived-state.mdx
@@ -9,7 +9,7 @@ import { DoubleCounter } from "~/xania/DoubleCounter";
 import { PokemonProfile } from  "~/xania/PokemonProfile";
 import { PokemonApp } from "~/xania/PokemonApp";
 
-In the following example we map every count value to it's `double` and `triple` and show that in the view. Notice that `triple` is wrapped in a *Promise*. **Xania**'s runtime will automatically recognise this and await the result before showing the end value in the view. This is useful, as we will see in the next section, when we want to asynchronuously load data from an *API*
+In the following example, we map every count value to its `double` and `triple` and show that in the view. Notice that `triple` is wrapped in a *Promise*. **Xania**'s runtime will automatically recognise this and await the result before showing the end value in the view. This is useful, as we will see in the next section, when we want to asynchronuously load data from an *API*.
 
 ```jsx { 3, 4 }
 function Component() {

--- a/src/content/docs/en/concepts/events.mdx
+++ b/src/content/docs/en/concepts/events.mdx
@@ -9,7 +9,7 @@ import { DoubleCounter } from "~/xania/DoubleCounter";
 import { PokemonProfile } from  "~/xania/PokemonProfile";
 import { PokemonApp } from "~/xania/PokemonApp";
 
-**Function Components** are the building blocks of a xania application. They not only represents  the structure of the DOM, but also contains **commands** and **subscriptions**. In the following examples we will gradually learn about each these concepts.
+**Function Components** are the building blocks of a xania application. They not only represent the structure of the DOM, but also contain **commands** and **subscriptions**. In the following examples we will gradually learn about each these concepts.
 
 ### Hello world
 Let's first start with a static / stateless example
@@ -27,4 +27,4 @@ function HelloWorld(props: { name }) {
 
 <HelloWorld name="Xania" client:only="xania"  />
 
-JSX in **xania** looks much like **react**, props defines attributes and children (not used in this example) and `click` event is bound to a callback function which prints a log message to the console.
+JSX in **Xania** looks much like **React**: props defines attributes and children (not used in this example), and the `click` event is bound to a callback function which prints a log message to the console.

--- a/src/content/docs/en/concepts/pokemon-app.mdx
+++ b/src/content/docs/en/concepts/pokemon-app.mdx
@@ -9,9 +9,12 @@ import { DoubleCounter } from "~/xania/DoubleCounter";
 import { PokemonProfile } from  "~/xania/PokemonProfile";
 import { PokemonApp } from "~/xania/PokemonApp";
 
-In this example we assembled everything we have learned so far to first, load pokemon list to show in selection box and second, when user clicks on a pokemon item then the corresponding details are asynchronuously loaded from the pokemon api. 
+In this example we assemble everything we've learned so far to:
 
-We also introduced a new state operartor `prop` which is a short hand for the `map` operator.
+1. load and show a Pokemon list as part of a select box, and
+2. when the user clicks on a Pokemon item, asynchronously load the corresponding details from the pokemon api. 
+
+We also introduced a new state operator, `prop`, which is shorthand for the `map` operator.
 
 ```jsx {2, 5}
 async function Component() {

--- a/src/content/docs/en/concepts/pokemon-intro.mdx
+++ b/src/content/docs/en/concepts/pokemon-intro.mdx
@@ -7,7 +7,7 @@ import { PokemonApp } from "~/xania/PokemonApp";
 
 In this example we assembled some of the core concepts of **Xania**. In the next sections we will learn about each concept separately. Or you could jump immediately to the final [final code](../pokemon-app) if you are confident you can infer how it works from the implementation.
 
-Notice that when you click many times, then the UI is not responding for the duration of clicks. This is because **Xania** keeps track of the pending clicks and invalidates it automatically when new click is received. In Rxjs this is achieved using **switchMap** operator, but in **Xania** it is the default behavior.
+Notice that when you click many times, the UI does not respond for the duration of clicks. This is because **Xania** keeps track of the pending clicks and invalidates it automatically when new click is received. In Rxjs this is achieved using **switchMap** operator, but in **Xania** it is the default behavior.
 
 ```jsx
 <PokemonApp  />

--- a/src/content/docs/en/concepts/state.mdx
+++ b/src/content/docs/en/concepts/state.mdx
@@ -9,7 +9,7 @@ import { DoubleCounter } from "~/xania/DoubleCounter";
 import { PokemonProfile } from  "~/xania/PokemonProfile";
 import { PokemonApp } from "~/xania/PokemonApp";
 
-Next example will shows an example of dynamic view that depends on state that change over time. the changes are initiated via the click event.
+The next example will show an example of a dynamic view that depends on state that changes over time. The changes are initiated via the click event.
 
 ```jsx
 function Counter() {
@@ -33,13 +33,13 @@ function Counter() {
   const count = state(1);
 ```
 
-First we create a state with initial value of `1`. Naming is hard, `count` is not exactly a state object in the traditional sense, we cannot just peek into it to see the latest value after incrementing the count a couple of times. The actual value is stored and maintained in the xania runtime. the only way to access it's value is using update commands / messages
+First we create a state with initial value of `1`. Naming is hard, `count` is not exactly a state object in the traditional sense, we cannot just peek into it to see the latest value after incrementing the count a couple of times. The actual value is stored and maintained in the **Xania** runtime. The only way to access its value is by using update commands / messages
 
 #### 2 update(...)
 ```jsx
   const increment = update(count, (x) => x + 1)
 ```
-`button` Element binds the *click* event to the `increment` update command. Technically, `increment` is just a plain data object that describes how `count` change over time, it is also a special type of object which **Xania** accepts, instead of a callback function like we saw before in *Hello World* example.
+The `button` Element binds the *click* event to the `increment` update command. Technically, `increment` is just a plain data object that describes how `count` changes over time, it is also a special type of object which **Xania** accepts, instead of a callback function like we saw before in *Hello World* example.
 
-When triggered, **Xania** runtime will execute the `increment` to update the runtime state of the `count` and update the text content of the button accordingly. 
+When triggered, the **Xania** runtime will execute the `increment` to update the runtime state of the `count` and update the text content of the button accordingly. 
 

--- a/src/content/docs/en/getting-started.mdx
+++ b/src/content/docs/en/getting-started.mdx
@@ -4,7 +4,7 @@ description: A basic intro to Xania.
 i18nReady: true
 ---
 
-The default project template includes a set of examples that helps you understand how to use xania in most effective way.
+The default project template includes a set of examples that helps you understand how to use xania in the most effective way.
 
 :::tip[quick start]
 npm create xania

--- a/src/content/docs/en/introduction.mdx
+++ b/src/content/docs/en/introduction.mdx
@@ -4,7 +4,7 @@ description: A basic intro to Xania.
 i18nReady: true
 ---
 
-**Xania** is (just like react) a javascript view library for building reactive UI with JSX syntax. Unlinke React, client components can be async. Also state can be async too. This greately simplifies how we write 'React' code.
+**Xania** is (just like react) a javascript view library for building reactive UI with JSX syntax. Unlike React, client components can be async. Also, state can be async too. This greatly simplifies how we write 'React' code.
 
 ```jsx
 async function HelloWorld(props: { children }) {
@@ -22,7 +22,7 @@ async function HelloWorld(props: { children }) {
 
 - 🚀 **Blazingly fast:** The fastest implementation in the JavaScript framework benchmark.
 - 🔥 **React interop:** Xania components integrates seemlessly in a react application.
-- 😎  **Fine-grained reactivity:** No vdom / rerender of the components. Supports observables (e.g. rxjs ) as input from outside world to 
+- 😎  **Fine-grained reactivity:** No vdom / re-render of the components. Supports observables (e.g. rxjs ) as input from the outside world to 
 listen to changes and pinpoint the DOM that needs to update without recreating the DOM.
-- ⏰ **Async everywhere:** First class support for async components or any part of it, async update commands, async derived state, async everything, etc.... 
+- ⏰ **Async everywhere:** First-class support for async components, and all related aspects, e.g. async update commands, async derived state, etc.
 


### PR DESCRIPTION
Some suggested changes to grammar that may improve readability of the docs for your users.

Thanks for making Xania!